### PR TITLE
ID-6622-2: Move enable.certificate.revocation.checking entries from eidas.xml to SignModule_Connector_EC (INTERNAL-COMMIT)

### DIFF
--- a/docker/profiles/systest/connector/SignModule_Connector_EC.xml
+++ b/docker/profiles/systest/connector/SignModule_Connector_EC.xml
@@ -1,0 +1,78 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Copyright (c) 2024 by European Commission
+  ~
+  ~ Licensed under the EUPL, Version 1.2 or - as soon they will be
+  ~ approved by the European Commission - subsequent versions of the
+  ~ EUPL (the "Licence");
+  ~ You may not use this work except in compliance with the Licence.
+  ~ You may obtain a copy of the Licence at:
+  ~ https://joinup.ec.europa.eu/page/eupl-text-11-12
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the Licence is distributed on an "AS IS" basis,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+  ~ implied.
+  ~ See the Licence for the specific language governing permissions and
+  ~ limitations under the Licence.
+  -->
+
+<!DOCTYPE properties SYSTEM "http://java.sun.com/dtd/properties.dtd">
+
+<properties>
+	<comment>Elliptic Curve Signing Example: Software Keystores</comment>
+		<!-- ADD THESE TWO LINES TO DISABLE REVOCATION CHECKING -->
+		<entry key="enable.certificate.revocation.checking">false</entry>
+		<entry key="enable.certificate.revocation.soft.fail">true</entry>
+
+	<!-- Request Signing with ECDSA -->
+	<!--Algorithm-->
+		<!--<entry key="signature.algorithm">http://www.w3.org/2001/04/xmldsig-more#ecdsa-sha256</entry>-->
+		<!--<entry key="signature.algorithm">http://www.w3.org/2001/04/xmldsig-more#ecdsa-sha384</entry>-->
+		<entry key="signature.algorithm">http://www.w3.org/2001/04/xmldsig-more#ecdsa-sha512</entry> <!--default when omitted-->
+	<!-- Key with Brainpool P256r1 curve -->
+		<!-- <entry key="issuer">CN=local-ka-demo-cert, OU=DIGIT, O=European Comission, L=Brussels, ST=Belgium, C=BE</entry>
+		<entry key="serialNumber">2EAAA5F6A93C6BB0581DC8388501FAD06F77F394</entry> -->
+	<!-- Key with NIST P-256 curve -->
+		<entry key="issuer">CN=nistP256-cert, OU=DIGIT, O=EC, L=Brussels, ST=Belgium, C=BE</entry>
+		<entry key="serialNumber">54CACC6D79C6C6998741E57E007BFF0542778E5A</entry>
+
+
+<!-- Metadata Signing with ECDSA-->
+	<!--Algorithm-->
+		<!--<entry key="metadata.signature.algorithm">http://www.w3.org/2001/04/xmldsig-more#ecdsa-sha256</entry>-->
+		<!--<entry key="metadata.signature.algorithm">http://www.w3.org/2001/04/xmldsig-more#ecdsa-sha384</entry>-->
+		<entry key="metadata.signature.algorithm">http://www.w3.org/2001/04/xmldsig-more#ecdsa-sha512</entry> <!--default when omitted-->
+	<!-- Self Signed -->
+		<entry key="metadata.issuer">CN=nistP256-cert, OU=DIGIT, O=EC, L=Brussels, ST=Belgium, C=BE</entry>
+		<entry key="metadata.serialNumber">54CACC6D79C6C6998741E57E007BFF0542778E5A</entry>
+	<!-- Trust Chain -->
+		<!--<entry key="metadata.issuer">C=EU, O=European Commission, OU=eID team, CN=intermediateCAMetadata</entry>-->
+		<!--<entry key="metadata.serialNumber">7278ECE783D310FB6E84561BFF07C01582FD8AFA</entry>-->
+
+	<!-- Keystore Definitions -->
+	<entry key="1.keyStorePath">./keystore/eidasKeyStore.p12</entry>
+	<entry key="1.keyStorePassword">local-demo</entry>
+	<entry key="1.keyPassword">local-demo</entry>
+	<entry key="1.keyStoreType">PKCS12</entry>
+
+	<entry key="2.keyStorePath">./keystore/eidasKeyStore_METADATA_EC.p12</entry>
+	<entry key="2.keyStorePassword">local-demo</entry>
+	<entry key="2.keyPassword">local-demo</entry>
+	<entry key="2.keyStoreType">PKCS12</entry>
+
+	<entry key="3.keyStorePath">./keystore/eidasKeyStore_METADATA_TC_EC.p12</entry>
+	<entry key="3.keyStorePassword">local-demo</entry>
+	<entry key="3.keyPassword">local-demo</entry>
+	<entry key="3.keyStoreType">PKCS12</entry>
+
+	<!-- TRUSTSTORE -->
+	<entry key="4.keyStorePath">./keystore/eidasTrustStore.p12</entry>
+	<entry key="4.keyStorePassword">local-demo</entry>
+	<entry key="4.keyStoreType">PKCS12</entry>
+	<entry key="4.keyStorePurpose">TRUSTSTORE</entry>
+	<!-- Note:
+	Certificate-only .p12 keystores are best made and verified with keytool not openssl.
+	The property "keyPassword" is required if the software keystore contains private keys.
+	-->
+</properties>

--- a/docker/profiles/systest/connector/eidas.xml
+++ b/docker/profiles/systest/connector/eidas.xml
@@ -101,5 +101,5 @@
     <entry key="specific.connector.response.receiver">https://eidas-demo-ca.eidasnode.dev/SpecificConnector/ConnectorResponse</entry>
 
     <entry key="disallow.self.signed.certificate">false</entry>
-    <entry key="enable.certificate.revocation.checking">false</entry>
+
 </properties>

--- a/docker/profiles/systest/proxy/eidas.xml
+++ b/docker/profiles/systest/proxy/eidas.xml
@@ -59,5 +59,5 @@
     <entry key="specific.proxyservice.request.receiver">https://eidas-demo-ca.eidasnode.dev/SpecificProxyService/ProxyServiceRequest</entry>
 
     <entry key="disallow.self.signed.certificate">false</entry>
-    <entry key="enable.certificate.revocation.checking">false</entry>
+
 </properties>

--- a/docker/profiles/test/connector/SignModule_Connector_EC.xml
+++ b/docker/profiles/test/connector/SignModule_Connector_EC.xml
@@ -1,0 +1,78 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Copyright (c) 2024 by European Commission
+  ~
+  ~ Licensed under the EUPL, Version 1.2 or - as soon they will be
+  ~ approved by the European Commission - subsequent versions of the
+  ~ EUPL (the "Licence");
+  ~ You may not use this work except in compliance with the Licence.
+  ~ You may obtain a copy of the Licence at:
+  ~ https://joinup.ec.europa.eu/page/eupl-text-11-12
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the Licence is distributed on an "AS IS" basis,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+  ~ implied.
+  ~ See the Licence for the specific language governing permissions and
+  ~ limitations under the Licence.
+  -->
+
+<!DOCTYPE properties SYSTEM "http://java.sun.com/dtd/properties.dtd">
+
+<properties>
+	<comment>Elliptic Curve Signing Example: Software Keystores</comment>
+		<!-- ADD THESE TWO LINES TO DISABLE REVOCATION CHECKING -->
+		<entry key="enable.certificate.revocation.checking">false</entry>
+		<entry key="enable.certificate.revocation.soft.fail">true</entry>
+
+	<!-- Request Signing with ECDSA -->
+	<!--Algorithm-->
+		<!--<entry key="signature.algorithm">http://www.w3.org/2001/04/xmldsig-more#ecdsa-sha256</entry>-->
+		<!--<entry key="signature.algorithm">http://www.w3.org/2001/04/xmldsig-more#ecdsa-sha384</entry>-->
+		<entry key="signature.algorithm">http://www.w3.org/2001/04/xmldsig-more#ecdsa-sha512</entry> <!--default when omitted-->
+	<!-- Key with Brainpool P256r1 curve -->
+		<!-- <entry key="issuer">CN=local-ka-demo-cert, OU=DIGIT, O=European Comission, L=Brussels, ST=Belgium, C=BE</entry>
+		<entry key="serialNumber">2EAAA5F6A93C6BB0581DC8388501FAD06F77F394</entry> -->
+	<!-- Key with NIST P-256 curve -->
+		<entry key="issuer">CN=nistP256-cert, OU=DIGIT, O=EC, L=Brussels, ST=Belgium, C=BE</entry>
+		<entry key="serialNumber">54CACC6D79C6C6998741E57E007BFF0542778E5A</entry>
+
+
+<!-- Metadata Signing with ECDSA-->
+	<!--Algorithm-->
+		<!--<entry key="metadata.signature.algorithm">http://www.w3.org/2001/04/xmldsig-more#ecdsa-sha256</entry>-->
+		<!--<entry key="metadata.signature.algorithm">http://www.w3.org/2001/04/xmldsig-more#ecdsa-sha384</entry>-->
+		<entry key="metadata.signature.algorithm">http://www.w3.org/2001/04/xmldsig-more#ecdsa-sha512</entry> <!--default when omitted-->
+	<!-- Self Signed -->
+		<entry key="metadata.issuer">CN=nistP256-cert, OU=DIGIT, O=EC, L=Brussels, ST=Belgium, C=BE</entry>
+		<entry key="metadata.serialNumber">54CACC6D79C6C6998741E57E007BFF0542778E5A</entry>
+	<!-- Trust Chain -->
+		<!--<entry key="metadata.issuer">C=EU, O=European Commission, OU=eID team, CN=intermediateCAMetadata</entry>-->
+		<!--<entry key="metadata.serialNumber">7278ECE783D310FB6E84561BFF07C01582FD8AFA</entry>-->
+
+	<!-- Keystore Definitions -->
+	<entry key="1.keyStorePath">./keystore/eidasKeyStore.p12</entry>
+	<entry key="1.keyStorePassword">local-demo</entry>
+	<entry key="1.keyPassword">local-demo</entry>
+	<entry key="1.keyStoreType">PKCS12</entry>
+
+	<entry key="2.keyStorePath">./keystore/eidasKeyStore_METADATA_EC.p12</entry>
+	<entry key="2.keyStorePassword">local-demo</entry>
+	<entry key="2.keyPassword">local-demo</entry>
+	<entry key="2.keyStoreType">PKCS12</entry>
+
+	<entry key="3.keyStorePath">./keystore/eidasKeyStore_METADATA_TC_EC.p12</entry>
+	<entry key="3.keyStorePassword">local-demo</entry>
+	<entry key="3.keyPassword">local-demo</entry>
+	<entry key="3.keyStoreType">PKCS12</entry>
+
+	<!-- TRUSTSTORE -->
+	<entry key="4.keyStorePath">./keystore/eidasTrustStore.p12</entry>
+	<entry key="4.keyStorePassword">local-demo</entry>
+	<entry key="4.keyStoreType">PKCS12</entry>
+	<entry key="4.keyStorePurpose">TRUSTSTORE</entry>
+	<!-- Note:
+	Certificate-only .p12 keystores are best made and verified with keytool not openssl.
+	The property "keyPassword" is required if the software keystore contains private keys.
+	-->
+</properties>

--- a/docker/profiles/test/connector/eidas.xml
+++ b/docker/profiles/test/connector/eidas.xml
@@ -101,5 +101,4 @@
     <entry key="specific.connector.response.receiver">https://eidas-demo-ca.test.eidasnode.no/SpecificConnector/ConnectorResponse</entry>
 
     <entry key="disallow.self.signed.certificate">false</entry>
-    <entry key="enable.certificate.revocation.checking">false</entry>
 </properties>

--- a/docker/profiles/test/proxy/eidas.xml
+++ b/docker/profiles/test/proxy/eidas.xml
@@ -59,5 +59,5 @@
     <entry key="specific.proxyservice.request.receiver">https://eidas-demo-ca.test.eidasnode.no/SpecificProxyService/ProxyServiceRequest</entry>
 
     <entry key="disallow.self.signed.certificate">false</entry>
-    <entry key="enable.certificate.revocation.checking">false</entry>
+
 </properties>


### PR DESCRIPTION
SAK:
ID-6622-2

Sjekklister:  
Eigar:

- [x] Vurdert Manual deploy
- [x] Vurdert "internal"
- [x] Avhengigheter til andre saker avklart
- [x] Har kjørt opp lokalt med docker-compose og testet en innlogging
- [x] Oppdatering/oppretting av regresjonstester er avklart/utført

Kodeles:

- [ ] Lesbar kode, nødvendige kommentarer
- [ ] Sak er godt nok forklart/dokumentert
- [ ] Løyser saka
- [ ] Risikovurdering ok
- [ ] Nødvendige regresjonstester er oppdatert/oppretta/planlagt
- [ ] Har oppdatert readme